### PR TITLE
upgrade to api v1.2.6 - fixes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,25 @@ des [Auswärtigen Amtes](https://www.auswaertiges-amt.de/de/) im Rahmen der
 Die Schnittstelle kann deaktiviert werden, in dem Fall wird ein leeres JSON-Objekt zurückgegeben.
 
 ## Fehlerfall
-    
+
 Im Fehlerfall wird ein leeres JSON-Objekt zurückgegeben.
 
 ## Nutzungsbedingungen
 
 Die Nutzungsbedingungen sind auf der [OpenData-Schnittstelle](https://www.auswaertiges-amt.de/de/open-data-schnittstelle/736118)
-des Auswärtigen Amtes zu finden. 
+des Auswärtigen Amtes zu finden.
 
 ## Änderungen [(offizielles Changelog)](https://www.auswaertiges-amt.de/de/-/2412916)
 
+### version [1.2.6](https://www.auswaertiges-amt.de/de/-/2412916) - (08.12.2021)
+
+Es werden zusätzlich zu jedem Land **Ländercodes** mit jeweils **zwei Buchstaben** mit ausgegeben.
+
+Die Länderkürzel werden bei [`/travelwarning`](https://travelwarning.api.bund.dev/#operations-default-getTravelwarning) und [`/travelwarning/{contentId}`](https://travelwarning.api.bund.dev/#operations-default-getSingleTravelwarning) in einem neuen Attribut ausgegeben z.B. in: [`/travelwarning/199124`](https://www.auswaertiges-amt.de/opendata/travelwarning/199124).
+
 ### version [1.2.5](https://www.auswaertiges-amt.de/de/-/2412916) (ursprünglich geplant für Ende September 2021)
 
-*Einführung verzögert sich*
+`content` (-> Details des Reise- und Sicherheitshinweis) wurde von [`/travelwarning`](https://travelwarning.api.bund.dev/#operations-default-getTravelwarning)
+entfernt -> bitte ab jetzt [`/travelwarning/{contentId}`](https://travelwarning.api.bund.dev/#operations-default-getSingleTravelwarning) nutzen um `content` abzufragen
 
-`content` (-> Details des Reise- und Sicherheitshinweis) wurde von [`/travelwarning`](#operations-default-getTravelwarning)
-entfernt -> bitte ab jetzt [`/travelwarning/{contentId}`](#operations-default-getSingleTravelwarning) nutzen um `content` abzufragen
-
-`flagURL` (-> Details des Reise- und Sicherheitshinweis) ist noch (Ende November 2021) präsent soll aber zukünftig entfernt werden -> es werden keine **Flaggen** mehr angeboten
-
+`flagURL` (-> Flaggen der Länder) wurde entfernt.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,15 +21,19 @@ info:
 
     ## Änderungen [(offizielles Changelog)](https://www.auswaertiges-amt.de/de/-/2412916)
 
+    ### version [1.2.6](https://www.auswaertiges-amt.de/de/-/2412916) - (08.12.2021)
+
+    Es werden zusätzlich zu jedem Land **Ländercodes** mit jeweils **zwei Buchstaben** mit ausgegeben.
+
+
+    Die Länderkürzel werden bei [`/travelwarning`](#operations-default-getTravelwarning) und [`/travelwarning/{contentId}`](#operations-default-getSingleTravelwarning) in einem neuen Attribut ausgegeben z.B. in: [`/travelwarning/199124`](https://www.auswaertiges-amt.de/opendata/travelwarning/199124).
+
     ### version [1.2.5](https://www.auswaertiges-amt.de/de/-/2412916) (ursprünglich geplant für Ende September 2021)
 
-    *Einführung verzögert sich*
-
-
     `content` (-> Details des Reise- und Sicherheitshinweis) wurde von [`/travelwarning`](#operations-default-getTravelwarning) entfernt -> bitte ab jetzt [`/travelwarning/{contentId}`](#operations-default-getSingleTravelwarning) nutzen um `content` abzufragen
-    
 
-    `flagURL` (-> Details des Reise- und Sicherheitshinweis) ist noch (Ende November 2021) präsent soll aber zukünftig entfernt werden -> es werden keine **Flaggen** mehr angeboten
+
+    `flagURL` (-> Details des Reise- und Sicherheitshinweis) wurde entfernt -> es werden keine **Flaggen** mehr angeboten
 
   version: 1.2.6
   title: >-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -31,8 +31,9 @@ info:
 
     `flagURL` (-> Details des Reise- und Sicherheitshinweis) ist noch (Ende November 2021) präsent soll aber zukünftig entfernt werden -> es werden keine **Flaggen** mehr angeboten
 
-  version: 1.0.1
-  title: Auswärtiges Amt: Reisewarnungen OpenData Schnittstelle
+  version: 1.2.6
+  title: >-
+    Auswärtiges Amt: Reisewarnungen OpenData Schnittstelle
   termsOfService: 'https://www.auswaertiges-amt.de/de/open-data-schnittstelle/736118'
 
 servers:
@@ -219,13 +220,18 @@ components:
           type: number
           description: 'Zeitstempel, seit wann der Reisehinweis gilt'
           example: 1499681492000
-        flagUrl:
-          type: string
-          description: 'URL der Länderflagge -> Achtung: Dieses Attribut soll zukünftig entfernt werden!'
-          example: 'https://www.auswaertiges-amt.de/blob/1234.jpg'
         title:
           type: string
           description: Titel des Landes
+          example: >-
+            Deutschland: Reise- und Sicherheitshinweise
+        CountryCode:
+          type: string
+          description: Zweistelliger Ländercode
+          example: DE
+        CountryName:
+          type: string
+          description: (Deutscher) Name des Landes
           example: Deutschland
         warning:
           type: boolean
@@ -234,6 +240,16 @@ components:
         partialWarning:
           type: boolean
           description: Ob eine Teilreisewarnung ausgesprochen wurde
+          example: false
+        situationWarning:
+          type: boolean
+          description: >-
+           Steht aktuell (Januar 2022) für *„COVID-19-bedingte Reisewarnung“* kann sich in Zukunft möglicherweise ändern.
+          example: false
+        situationPartWarning:
+          type: boolean
+          description: >-
+           Steht aktuell (Januar 2022) für *„COVID-19-bedingte Teilreisewarnung“* kann sich in Zukunft möglicherweise ändern.
           example: false
         content:
           type: string
@@ -250,13 +266,18 @@ components:
           type: number
           description: 'Zeitstempel, seit wann der Reisehinweis gilt'
           example: 1499681492000
-        flagUrl:
-          type: string
-          description: URL der Länderflagge
-          example: 'https://www.auswaertiges-amt.de/blob/1234.jpg'
         title:
           type: string
           description: Titel des Landes
+          example: >-
+            Deutschland: Reise- und Sicherheitshinweise
+        CountryCode:
+          type: string
+          description: Zweistelliger Ländercode
+          example: DE
+        CountryName:
+          type: string
+          description: (Deutscher) Name des Landes
           example: Deutschland
         warning:
           type: boolean
@@ -265,6 +286,16 @@ components:
         partialWarning:
           type: boolean
           description: Ob eine Teilreisewarnung ausgesprochen wurde
+          example: false
+        situationWarning:
+          type: boolean
+          description: >-
+           Steht aktuell (Januar 2022) für *„COVID-19-bedingte Reisewarnung“* kann sich in Zukunft möglicherweise ändern.
+          example: false
+        situationPartWarning:
+          type: boolean
+          description: >-
+           Steht aktuell (Januar 2022) für *„COVID-19-bedingte Teilreisewarnung“* kann sich in Zukunft möglicherweise ändern.
           example: false
     AdressListe:
       type: object


### PR DESCRIPTION
*English*

Hi @LilithWittmann, @wirthual :wave:

As @go-around mentioned in #6 **version 1.2.6** of the api has been published by the Auswärtiges Amt (AA) at the beginning of December 2021.

This MR fixes the broken OpenAPI syntax and integrates the changes to the API endpoints `/travelwarning` and `/travelwarning/{contentId}`.

Regards,
Jean-Luc

---

*German*

Hallo zusammen,

wie in #6 angesprochen, wurde version 1.2.6 der API durch das AA veröffentlicht.

Dieser Merge-Request enthält die Änderungen an der API und macht die OpenAPI-Syntax wieder lauffähig.

Viele Grüße,
Jean-Luc
